### PR TITLE
Feat  bind event listener to return key

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -3,10 +3,6 @@ import { addMessageToChatHistory } from './chatWindow';
 import { onEnterPress, onFormSubmit } from './eventHandlers';
 
 export default function main() {
-  const helloWorld = () => console.log('Hello!');
-
   onEnterPress(addMessageToChatHistory);
   onFormSubmit(addMessageToChatHistory);
-
-  helloWorld();
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,0 +1,12 @@
+import '../css/index.css';
+import { addMessageToChatHistory } from './chatWindow';
+import { onEnterPress, onFormSubmit } from './eventHandlers';
+
+export default function main() {
+  const helloWorld = () => console.log('Hello!');
+
+  onEnterPress(addMessageToChatHistory);
+  onFormSubmit(addMessageToChatHistory);
+
+  helloWorld();
+}

--- a/src/js/app.spec.js
+++ b/src/js/app.spec.js
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+import main from './app.js';
+
+document.body.innerHTML = `<div class="chat-window">
+<div class="js-add-message-to-chat-history chat-window__messages">
+<div class="chat-window__message chat-window__message--incoming">hi</div>
+<div class="chat-window__message chat-window__message--outgoing">hello</div>
+<div class="chat-window__message chat-window__message--outgoing">hows it going?</div>
+<div class="chat-window__message chat-window__message--incoming">not bad</div>
+</div>
+<form class="chat-window__sender-features">
+  <label for="message-area" class="visually-hidden">Message area</label>
+  <textarea
+    name="message-area"
+    id="message-area"
+    class="chat-window__input"></textarea>
+  <button class="chat-window__send-button" type="submit">Send</button>
+</form>
+</div>`;
+
+describe('app.js', () => {
+  it('A good place for a test', () => {
+    main();
+  });
+});

--- a/src/js/app.spec.js
+++ b/src/js/app.spec.js
@@ -2,26 +2,19 @@
  * @jest-environment jsdom
  */
 import main from './app.js';
+import { addMessageToChatHistory } from './chatWindow.js';
+import { onEnterPress, onFormSubmit } from './eventHandlers.js';
 
-document.body.innerHTML = `<div class="chat-window">
-<div class="js-add-message-to-chat-history chat-window__messages">
-<div class="chat-window__message chat-window__message--incoming">hi</div>
-<div class="chat-window__message chat-window__message--outgoing">hello</div>
-<div class="chat-window__message chat-window__message--outgoing">hows it going?</div>
-<div class="chat-window__message chat-window__message--incoming">not bad</div>
-</div>
-<form class="chat-window__sender-features">
-  <label for="message-area" class="visually-hidden">Message area</label>
-  <textarea
-    name="message-area"
-    id="message-area"
-    class="chat-window__input"></textarea>
-  <button class="chat-window__send-button" type="submit">Send</button>
-</form>
-</div>`;
+jest.mock('./eventHandlers.js');
+jest.mock('./chatWindow.js');
 
 describe('app.js', () => {
-  it('A good place for a test', () => {
+  it('Runs onEnterPress with addMessageToChatHistory as a parameter', () => {
     main();
+    expect(onEnterPress).toHaveBeenCalledWith(addMessageToChatHistory);
+  });
+  it('Runs onFormSubmit with addMessageToChatHistory as a parameter', () => {
+    main();
+    expect(onFormSubmit).toHaveBeenCalledWith(addMessageToChatHistory);
   });
 });

--- a/src/js/app.spec.js
+++ b/src/js/app.spec.js
@@ -8,11 +8,12 @@ import { onEnterPress, onFormSubmit } from './eventHandlers.js';
 jest.mock('./eventHandlers.js');
 jest.mock('./chatWindow.js');
 
-describe('app.js', () => {
+describe('App Initialization', () => {
   it('Runs onEnterPress with addMessageToChatHistory as a parameter', () => {
     main();
     expect(onEnterPress).toHaveBeenCalledWith(addMessageToChatHistory);
   });
+
   it('Runs onFormSubmit with addMessageToChatHistory as a parameter', () => {
     main();
     expect(onFormSubmit).toHaveBeenCalledWith(addMessageToChatHistory);

--- a/src/js/eventHandler.spec.js
+++ b/src/js/eventHandler.spec.js
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { callbackOnFormSubmit, callbackWhenEnterIsPressed } from './eventHandlers';
+
+document.body.innerHTML = `
+<form class="chat-window__sender-features">
+  <label for="message-area" class="visually-hidden">Message area</label>
+  <textarea
+    name="message-area"
+    id="message-area"
+    class="chat-window__input">Hello World</textarea>
+  <button class="chat-window__send-button" type="submit">Send</button>
+</form>
+`;
+
+describe('eventHandler.js', () => {
+  it('Should run callback and set textarea to empty string on "Enter" key press', () => {
+    const callback = jest.fn();
+    callbackWhenEnterIsPressed(callback);
+
+    const textArea = document.querySelector('.chat-window__input');
+    const event = new KeyboardEvent('keypress', { keyCode: 13 });
+
+    textArea.dispatchEvent(event);
+
+    expect(textArea.value).toBe('');
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('Should run callback and set textarea to empty string on submit event', () => {
+    const callback = jest.fn();
+    callbackOnFormSubmit(callback);
+
+    const textArea = document.querySelector('.chat-window__input');
+    const chatForm = document.querySelector('.chat-window__sender-features');
+    const event = new Event('submit');
+
+    chatForm.dispatchEvent(event);
+
+    expect(textArea.value).toBe('');
+    expect(callback).toHaveBeenCalled();
+  });
+});

--- a/src/js/eventHandlers.js
+++ b/src/js/eventHandlers.js
@@ -1,0 +1,26 @@
+export const listenForKeypressAndConsoleMessage = () => {
+  console.log(document.body);
+  document.addEventListener('DOMContentLoaded', () => {
+    const textArea = document.querySelector('.chat-window__input');
+    textArea.addEventListener('keypress', (e) => {
+      // if key is 'Enter' key console message
+      if (e.keyCode === 13) {
+        e.preventDefault();
+        console.log(textArea.value);
+        textArea.value = '';
+      }
+    });
+  });
+};
+
+export const listenForSubmitAndConsoleMessage = () => {
+  document.addEventListener('DOMContentLoaded', () => {
+    const chatForm = document.querySelector('.chat-window__sender-features');
+    const textArea = document.querySelector('.chat-window__input');
+    chatForm.addEventListener('submit', (e) => {
+      e.preventDefault();
+      console.log(textArea.value);
+      textArea.value = '';
+    });
+  });
+};

--- a/src/js/eventHandlers.js
+++ b/src/js/eventHandlers.js
@@ -1,4 +1,4 @@
-export const callbackWhenEnterIsPressed = (callback) => {
+export const onEnterPress = (callback) => {
   const textArea = document.querySelector('.chat-window__input');
   textArea.addEventListener('keypress', (e) => {
     if (e.key === 'Enter') {
@@ -9,9 +9,9 @@ export const callbackWhenEnterIsPressed = (callback) => {
   });
 };
 
-export const callbackOnFormSubmit = (callback) => {
-  const chatForm = document.querySelector('.chat-window__sender-features');
+export const onFormSubmit = (callback) => {
   const textArea = document.querySelector('.chat-window__input');
+  const chatForm = document.querySelector('.chat-window__sender-features');
   chatForm.addEventListener('submit', (e) => {
     e.preventDefault();
     callback(textArea.value);

--- a/src/js/eventHandlers.js
+++ b/src/js/eventHandlers.js
@@ -1,8 +1,7 @@
 export const callbackWhenEnterIsPressed = (callback) => {
   const textArea = document.querySelector('.chat-window__input');
   textArea.addEventListener('keypress', (e) => {
-    // if key is 'Enter' key console message
-    if (e.keyCode === 13) {
+    if (e.key === 'Enter') {
       e.preventDefault();
       callback(textArea.value);
       textArea.value = '';

--- a/src/js/eventHandlers.js
+++ b/src/js/eventHandlers.js
@@ -1,17 +1,3 @@
-<<<<<<< HEAD
-export const listenForKeypressAndConsoleMessage = () => {
-  console.log(document.body);
-  document.addEventListener('DOMContentLoaded', () => {
-    const textArea = document.querySelector('.chat-window__input');
-    textArea.addEventListener('keypress', (e) => {
-      // if key is 'Enter' key console message
-      if (e.keyCode === 13) {
-        e.preventDefault();
-        console.log(textArea.value);
-        textArea.value = '';
-      }
-    });
-=======
 export const callbackWhenEnterIsPressed = (callback) => {
   const textArea = document.querySelector('.chat-window__input');
   textArea.addEventListener('keypress', (e) => {
@@ -21,7 +7,6 @@ export const callbackWhenEnterIsPressed = (callback) => {
       callback(textArea.value);
       textArea.value = '';
     }
->>>>>>> f743a81 (refactor: change eventHandlers to accept callbacks)
   });
 };
 

--- a/src/js/eventHandlers.js
+++ b/src/js/eventHandlers.js
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 export const listenForKeypressAndConsoleMessage = () => {
   console.log(document.body);
   document.addEventListener('DOMContentLoaded', () => {
@@ -10,17 +11,26 @@ export const listenForKeypressAndConsoleMessage = () => {
         textArea.value = '';
       }
     });
+=======
+export const callbackWhenEnterIsPressed = (callback) => {
+  const textArea = document.querySelector('.chat-window__input');
+  textArea.addEventListener('keypress', (e) => {
+    // if key is 'Enter' key console message
+    if (e.keyCode === 13) {
+      e.preventDefault();
+      callback(textArea.value);
+      textArea.value = '';
+    }
+>>>>>>> f743a81 (refactor: change eventHandlers to accept callbacks)
   });
 };
 
-export const listenForSubmitAndConsoleMessage = () => {
-  document.addEventListener('DOMContentLoaded', () => {
-    const chatForm = document.querySelector('.chat-window__sender-features');
-    const textArea = document.querySelector('.chat-window__input');
-    chatForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      console.log(textArea.value);
-      textArea.value = '';
-    });
+export const callbackOnFormSubmit = (callback) => {
+  const chatForm = document.querySelector('.chat-window__sender-features');
+  const textArea = document.querySelector('.chat-window__input');
+  chatForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    callback(textArea.value);
+    textArea.value = '';
   });
 };

--- a/src/js/eventHandlers.spec.js
+++ b/src/js/eventHandlers.spec.js
@@ -18,8 +18,8 @@ document.body.innerHTML = `
 const textArea = document.querySelector('.chat-window__input');
 const chatForm = document.querySelector('.chat-window__sender-features');
 
-describe('callbackWhenEnterIsPressed', () => {
-  it('Should run callback on "Enter" key press', () => {
+describe('onEnterIsPressed', () => {
+  it('Runs callback on "Enter" key press', () => {
     const callback = jest.fn();
     onEnterPress(callback);
 
@@ -30,7 +30,7 @@ describe('callbackWhenEnterIsPressed', () => {
     expect(callback).toHaveBeenCalled();
   });
 
-  it('Should set textarea to empty string on "Enter" key press', () => {
+  it('Sets textarea to empty string on "Enter" key press', () => {
     const callback = jest.fn();
     onEnterPress(callback);
 
@@ -42,8 +42,8 @@ describe('callbackWhenEnterIsPressed', () => {
   });
 });
 
-describe('callbackOnFormSubmit', () => {
-  it('Should run callback and set textarea to empty string on submit event', () => {
+describe('onFormSubmit', () => {
+  it('Runs callback on submit event', () => {
     const callback = jest.fn();
     onFormSubmit(callback);
 
@@ -54,7 +54,7 @@ describe('callbackOnFormSubmit', () => {
     expect(callback).toHaveBeenCalled();
   });
 
-  it('Should set textarea to empty string on form submit', () => {
+  it('Sets textarea to empty string on form submit', () => {
     const callback = jest.fn();
     onFormSubmit(callback);
 

--- a/src/js/eventHandlers.spec.js
+++ b/src/js/eventHandlers.spec.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { callbackOnFormSubmit, callbackWhenEnterIsPressed } from './eventHandlers';
+import { onFormSubmit, onEnterPress } from './eventHandlers';
 
 document.body.innerHTML = `
 <form class="chat-window__sender-features">
@@ -15,31 +15,53 @@ document.body.innerHTML = `
 </form>
 `;
 
-describe('eventHandler.js', () => {
-  it('Should run callback and set textarea to empty string on "Enter" key press', () => {
-    const callback = jest.fn();
-    callbackWhenEnterIsPressed(callback);
+const textArea = document.querySelector('.chat-window__input');
+const chatForm = document.querySelector('.chat-window__sender-features');
 
-    const textArea = document.querySelector('.chat-window__input');
+describe('callbackWhenEnterIsPressed', () => {
+  it('Should run callback on "Enter" key press', () => {
+    const callback = jest.fn();
+    onEnterPress(callback);
+
+    const event = new KeyboardEvent('keypress', { key: 'Enter' });
+
+    textArea.dispatchEvent(event);
+
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('Should set textarea to empty string on "Enter" key press', () => {
+    const callback = jest.fn();
+    onEnterPress(callback);
+
     const event = new KeyboardEvent('keypress', { key: 'Enter' });
 
     textArea.dispatchEvent(event);
 
     expect(textArea.value).toBe('');
+  });
+});
+
+describe('callbackOnFormSubmit', () => {
+  it('Should run callback and set textarea to empty string on submit event', () => {
+    const callback = jest.fn();
+    onFormSubmit(callback);
+
+    const event = new Event('submit');
+
+    chatForm.dispatchEvent(event);
+
     expect(callback).toHaveBeenCalled();
   });
 
-  it('Should run callback and set textarea to empty string on submit event', () => {
+  it('Should set textarea to empty string on form submit', () => {
     const callback = jest.fn();
-    callbackOnFormSubmit(callback);
+    onFormSubmit(callback);
 
-    const textArea = document.querySelector('.chat-window__input');
-    const chatForm = document.querySelector('.chat-window__sender-features');
     const event = new Event('submit');
 
     chatForm.dispatchEvent(event);
 
     expect(textArea.value).toBe('');
-    expect(callback).toHaveBeenCalled();
   });
 });

--- a/src/js/eventHandlers.spec.js
+++ b/src/js/eventHandlers.spec.js
@@ -21,7 +21,7 @@ describe('eventHandler.js', () => {
     callbackWhenEnterIsPressed(callback);
 
     const textArea = document.querySelector('.chat-window__input');
-    const event = new KeyboardEvent('keypress', { keyCode: 13 });
+    const event = new KeyboardEvent('keypress', { key: 'Enter' });
 
     textArea.dispatchEvent(event);
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,5 +1,10 @@
 import '../css/index.css';
+import { addMessageToChatHistory } from './chatWindow';
+import { callbackWhenEnterIsPressed, callbackOnFormSubmit } from './eventHandlers';
 
 const helloWorld = () => console.log('Hello!');
+
+callbackWhenEnterIsPressed(addMessageToChatHistory);
+callbackOnFormSubmit(addMessageToChatHistory);
 
 helloWorld();

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,10 +1,3 @@
-import '../css/index.css';
-import { addMessageToChatHistory } from './chatWindow';
-import { callbackWhenEnterIsPressed, callbackOnFormSubmit } from './eventHandlers';
+import main from './app';
 
-const helloWorld = () => console.log('Hello!');
-
-callbackWhenEnterIsPressed(addMessageToChatHistory);
-callbackOnFormSubmit(addMessageToChatHistory);
-
-helloWorld();
+main();

--- a/src/js/index.spec.js
+++ b/src/js/index.spec.js
@@ -1,5 +1,0 @@
-import './index.js';
-
-describe('Index.js', () => {
-  it.todo('A good place for a test');
-});


### PR DESCRIPTION
## Description
Add event listeners to both the return keypress and submit event. Added tests for these event listeners.

## Spec

See Issue: [FSA21V2-62](https://sparkbox.atlassian.net/browse/FSA21V2-62)

## Validation
<!-- delete anything irrelevant to this PR -->

- [x] This PR has code changes, and our linters still pass.
- [x] This PR has new code, so new tests were added or updated, and they pass.
- [ ] This PR affects production code, so it was browser tested (see below).

### To Validate

1. Make sure all PR Checks have passed.
1. Pull down all related branches.
1. Navigate to... _[continue instructions here]_

### Browser Testing
<!-- Delete if irrelevant to this issue -->

#### macOS

- [ ] Chrome, current release
- [ ] Firefox, current release
- [ ] Safari, current release

#### Windows

- [ ] Chrome, current release
- [ ] Firefox, current release
- [ ] Edge, current release

#### Mobile

- [ ] Mobile Safari on iPad
- [ ] Mobile Safari on iPhone
